### PR TITLE
login features tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ jobs:
         - echo "Running tests"
         - |
           sshpass -p $PIPELINE_SERVER_PASSWORD ssh -o StrictHostKeyChecking=no root@$PIPELINE_SERVER_IP_ADDRESS << 'ENDSSH'
-          docker exec tg_chat_mate-bot-1 pipenv run python tests/healf_check.py
+          docker exec tg_chat_mate-bot-1 pipenv pytest tests/healf_check.py -v
           ENDSSH
       after_failure:
         - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ jobs:
         - echo "Running tests"
         - |
           sshpass -p $PIPELINE_SERVER_PASSWORD ssh -o StrictHostKeyChecking=no root@$PIPELINE_SERVER_IP_ADDRESS << 'ENDSSH'
-          docker exec tg_chat_mate-bot-1 pipenv pytest tests/healf_check.py -v
+          docker exec tg_chat_mate-bot-1 pipenv run pytest tests/healf_check.py -v
           ENDSSH
       after_failure:
         - |

--- a/bot/Dockerfile
+++ b/bot/Dockerfile
@@ -6,7 +6,7 @@ COPY . /home/
 
 RUN pip install pipenv
 
-RUN pipenv install --ignore-pipfile
+RUN pipenv install --dev --ignore-pipfile
 
 EXPOSE 2005
 

--- a/bot/Pipfile
+++ b/bot/Pipfile
@@ -27,6 +27,7 @@ types-decorator = "*"
 types-PyYAML = "*"
 types-requests = "*"
 pylint = "*"
+pytest = "*"
 
 [requires]
 python_version = "3.10"

--- a/bot/Pipfile.lock
+++ b/bot/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a1d8e28bbc8cd2b33ed96e25dab067073bbc47e6d687823a93c3c90aa30c8215"
+            "sha256": "40dca5f4c5159930ef301eb713177b19258e33037442a7f3f30405ff16cdf1e3"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1133,6 +1133,14 @@
             "markers": "python_version < '3.11'",
             "version": "==0.3.7"
         },
+        "exceptiongroup": {
+            "hashes": [
+                "sha256:4bfd3996ac73b41e9b9628b04e079f193850720ea5945fc96a08633c66912f14",
+                "sha256:91f5c769735f051a4290d52edd0858999b57e5876e9f85937691bd4c9fa3ed68"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==1.2.0"
+        },
         "filelock": {
             "hashes": [
                 "sha256:521f5f56c50f8426f5e03ad3b281b490a87ef15bc6c526f168290f0c7148d44e",
@@ -1179,6 +1187,14 @@
             ],
             "markers": "python_version >= '3.5'",
             "version": "==3.6"
+        },
+        "iniconfig": {
+            "hashes": [
+                "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3",
+                "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.0"
         },
         "isort": {
             "hashes": [
@@ -1357,11 +1373,11 @@
         },
         "pip": {
             "hashes": [
-                "sha256:1fcaa041308d01f14575f6d0d2ea4b75a3e2871fe4f9c694976f908768e14174",
-                "sha256:55eb67bb6171d37447e82213be585b75fe2b12b359e993773aca4de9247a052b"
+                "sha256:5052d7889c1f9d05224cd41741acb7c5d6fa735ab34e339624a614eaaa7e7d76",
+                "sha256:7fd9972f96db22c8077a1ee2691b172c8089b17a5652a44494a9ecb0d78f9149"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==23.3.1"
+            "version": "==23.3.2"
         },
         "pip-api": {
             "hashes": [
@@ -1394,6 +1410,14 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==4.1.0"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:cf61ae8f126ac6f7c451172cf30e3e43d3ca77615509771b3a984a0730651e12",
+                "sha256:d89c696a773f8bd377d18e5ecda92b7a3793cbe66c87060a6fb58c7b6e1061f7"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==1.3.0"
         },
         "py-serializable": {
             "hashes": [
@@ -1442,6 +1466,14 @@
             ],
             "markers": "python_full_version >= '3.6.8'",
             "version": "==3.1.1"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:0d009c083ea859a71b76adf7c1d502e4bc170b80a8ef002da5806527b9591fac",
+                "sha256:d989d136982de4e3b29dabcc838ad581c64e8ed52c11fbe86ddebd9da0818cd5"
+            ],
+            "index": "pypi",
+            "version": "==7.4.3"
         },
         "pyyaml": {
             "hashes": [

--- a/bot/pytest.ini
+++ b/bot/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+filterwarnings = ignore::urllib3.exceptions.InsecureRequestWarning

--- a/bot/support_bot/misc.py
+++ b/bot/support_bot/misc.py
@@ -100,7 +100,7 @@ def get_manager_username_from_jwt(token):
         )
         username = payload["username"]
         return username
-    except jwt.DecodeError:
+    except (jwt.DecodeError, jwt.ExpiredSignatureError):
         return None
 
 

--- a/bot/support_bot/routes/manager_auth.py
+++ b/bot/support_bot/routes/manager_auth.py
@@ -37,10 +37,12 @@ async def manager_check_token(request: Request):
     manager = get_manager_username_from_jwt(token)
     if manager is None:
         response = web.json_response(
-            {"error": "Wrong credentials"}, status=401
+            {"error": "Wrong token or it was expired"}, status=401
         )
         return set_cors_headers(response)
-    response = web.json_response({"token": token}, status=200)
+    response = web.json_response(
+        {"token": token, "manager": manager}, status=200
+    )
     return set_cors_headers(response)
 
 

--- a/bot/tests/healf_check.py
+++ b/bot/tests/healf_check.py
@@ -9,7 +9,7 @@ class TestLogin:
     def setup_class(self):
         self.DOMAIN = getenv("DOMAIN")
         self.USER_NAME = "root"
-        self.PASSWORD = getenv("ROOT_PASSWORD")
+        self.PASSWORD = getenv("ROOT_PASSWORD", "empty_password")
 
     def test_check_login_page(self):
         login_url = f"https://{self.DOMAIN}/login"

--- a/bot/tests/healf_check.py
+++ b/bot/tests/healf_check.py
@@ -1,16 +1,68 @@
 from os import getenv
 
+import pytest
 import requests
 
-DOMAIN = getenv("DOMAIN")
 
+class TestLogin:
+    @pytest.fixture(autouse=True)
+    def setup_class(self):
+        self.DOMAIN = getenv("DOMAIN")
+        self.USER_NAME = "root"
+        self.PASSWORD = getenv("ROOT_PASSWORD")
 
-def check_login_page():
-    login_url = f"https://{DOMAIN}/login"
-    resp = requests.get(login_url, verify=False)
-    print(resp.text)
-    print(resp.status_code)
-    assert resp.status_code == 200
+    def test_check_login_page(self):
+        login_url = f"https://{self.DOMAIN}/login"
+        response = requests.get(login_url, verify=False)
+        assert response.status_code == 200, "Login page is not accessible"
 
+    def test_try_to_fail_get_token(self):
+        auth_endpoint_url = f"https://{self.DOMAIN}/tg-bot/login"
+        payload = {
+            "user_name": self.USER_NAME,
+            "password": self.PASSWORD + "?>asfl",
+        }
+        response = requests.post(auth_endpoint_url, json=payload, verify=False)
+        assert (
+            response.status_code == 401
+        ), "Invalid credentials should not be accepted"
 
-check_login_page()
+    def test_try_to_get_token(self):
+        auth_endpoint_url = f"https://{self.DOMAIN}/tg-bot/login"
+        payload = {"user_name": self.USER_NAME, "password": self.PASSWORD}
+        response = requests.post(auth_endpoint_url, json=payload, verify=False)
+        assert (
+            response.status_code == 200
+        ), "Valid credentials should be accepted"
+        assert "token" in response.json(), "Response should contain a token"
+
+    def test_token_check_logic(self):
+        auth_endpoint_url = f"https://{self.DOMAIN}/tg-bot/login"
+        payload = {"user_name": self.USER_NAME, "password": self.PASSWORD}
+        response = requests.post(auth_endpoint_url, json=payload, verify=False)
+        assert (
+            response.status_code == 200
+        ), "Valid credentials should be accepted"
+        token = response.json()["token"]
+
+        check_token_endpoint = f"https://{self.DOMAIN}/tg-bot/check_token"
+        check_token_payload = {"token": token}
+        response = requests.post(
+            check_token_endpoint, json=check_token_payload, verify=False
+        )
+        assert (
+            response.status_code == 200
+        ), "Valid credentials should be accepted"
+        assert response.json().get("manager") == self.USER_NAME
+
+    def test_wrong_token_check_logic(self):
+        wrong_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+
+        check_token_endpoint = f"https://{self.DOMAIN}/tg-bot/check_token"
+        check_token_payload = {"token": wrong_token}
+        response = requests.post(
+            check_token_endpoint, json=check_token_payload, verify=False
+        )
+        assert (
+            response.status_code == 401
+        ), "Valid credentials should be accepted"

--- a/bot/tests/healf_check.py
+++ b/bot/tests/healf_check.py
@@ -9,7 +9,7 @@ class TestLogin:
     def setup_class(self):
         self.DOMAIN = getenv("DOMAIN")
         self.USER_NAME = "root"
-        self.PASSWORD = getenv("ROOT_PASSWORD", "empty_password")
+        self.PASSWORD = getenv("ROOT_PASSWORD", "empty-password")
 
     def test_check_login_page(self):
         login_url = f"https://{self.DOMAIN}/login"


### PR DESCRIPTION
Closes #39

I have added tests for some login endpoints, for getting and checking token using `root` credentials, running these tests we could verify we are able to create token by verifying manager credentials and decode it back to get manager username, also we are testing wrong password entered and wrong token used cases. 

It's our first tests like this so it will also approve services are working fine, because we are able to call bot API (bot is running) and use MongoDB.

So now our post deploy tests are able to verify we have UI, BOT and MongoDB running fine.

Later we should add some tests for check login from UI maybe?

Closing 39 by this PR because we will no longer interested in different container for testing, we will set up after deploy and pre-deploy tests here inside bot container.