### PR TITLE
make bot docker file faster

### DIFF
--- a/bot/Dockerfile
+++ b/bot/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:3.10
+FROM python:3.10-alpine
+
+RUN apk add --no-cache libmagic
 
 WORKDIR /home
 
@@ -6,7 +8,7 @@ COPY Pipfile.lock /home/
 COPY Pipfile /home/
 
 RUN pip install pipenv
-RUN pipenv install --ignore-pipfile
+RUN pipenv install --ignore-pipfile --skip-lock
 
 COPY . /home/
 


### PR DESCRIPTION
We can use `python:3.10-alpine` to make our docker image building much more faster.

`python:3.10-alpine` don't include `libmagic` so we will install it additionally