### PR TITLE
Travis CI: Run python and typescript linting stages sequentially

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ jobs:
         - pipenv run isort --check-only support_bot tests
         - echo "Python linting completed successfully"
 
-    - stage: linting
       name: TypeScript linting
       script:
         - echo "Running TypeScript linting"


### PR DESCRIPTION
Solves issue https://github.com/Grommash9/tg_chat_mate/issues/169 

According to official Travis documentation:

> Stages group jobs that run in parallel and different stages run sequentially.

So, we just need to run Python linting and Typescript linting jobs in the same stage for them to run in parallel. In the current implementation, the stages where they used to run are both called 'linting.' However, this can be confusing and possibly lead to unpredictable behavior. Therefore, I'm removing the duplicate names and letting them be in the same stage.