### PR TITLE
docker file MacOS fix

### DIFF
--- a/bot/Dockerfile
+++ b/bot/Dockerfile
@@ -1,6 +1,4 @@
-FROM python:3.10-alpine
-
-RUN apk add --no-cache libmagic
+FROM python:3.10
 
 WORKDIR /home
 


### PR DESCRIPTION
It was gcc package missing from python3.10-apline image so I removed it because it will not run on MAC OS as it was before

Maybe later we can invistigate and fix it